### PR TITLE
chore: upgrade to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'strict'
 runs:
-  using: node16
+  using: node20
   main: ./dist/index.js


### PR DESCRIPTION
Please see deprecation notice for node 16 actions https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Should resolve https://github.com/xom9ikk/dotenv/issues/20